### PR TITLE
fix(ci): remove package-name from release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,7 +3,6 @@
   "release-type": "simple",
   "packages": {
     ".": {
-      "package-name": "unifiedmetrics",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary
- Removes `package-name: "unifiedmetrics"` from release-please config to fix component mismatch that prevented automatic tag creation on merged release PRs

## Context
Release-please was aborting with "There are untagged, merged release PRs outstanding" because the PR title component (`undefined`) didn't match the configured `package-name` (`unifiedmetrics`). The v0.4.0 release had to be tagged manually as a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusk-studio/UnifiedMetrics/pull/7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->