### PR TITLE
fix: exclude duplicate META-INF/LICENSE and NOTICE from shaded jars

### DIFF
--- a/platforms/bukkit/build.gradle.kts
+++ b/platforms/bukkit/build.gradle.kts
@@ -32,6 +32,15 @@ tasks {
     shadowJar {
         archiveClassifier.set("")
         mergeServiceFiles()
+        // Several shaded deps (okhttp, okio, retrofit, kotlin-stdlib, etc.)
+        // each ship their own META-INF/LICENSE.txt and META-INF/NOTICE.txt.
+        // Without an explicit filter shadow keeps them all, producing a JAR
+        // that Paper's plugin remapper rejects with
+        // "Duplicate entries detected: META-INF/LICENSE.txt, ..." via
+        // NeoForged ART. The canonical copies live in META-INF/LICENSE and
+        // META-INF/NOTICE (no .txt suffix) so dropping the duplicates is
+        // safe from a licensing standpoint.
+        exclude("META-INF/LICENSE*", "META-INF/NOTICE*")
         relocate("retrofit2", "dev.cubxity.plugins.metrics.libs.retrofit2")
         relocate("com.charleskorn", "dev.cubxity.plugins.metrics.libs.com.charleskorn")
         relocate("com.influxdb", "dev.cubxity.plugins.metrics.libs.com.influxdb")

--- a/platforms/bungee/build.gradle.kts
+++ b/platforms/bungee/build.gradle.kts
@@ -32,6 +32,12 @@ dependencies {
 tasks {
     shadowJar {
         archiveClassifier.set("")
+        // Shaded deps (okhttp, retrofit, kotlin-stdlib, etc.) each ship
+        // their own META-INF/LICENSE.txt and META-INF/NOTICE.txt. Without
+        // a filter the shadow plugin keeps them all, producing a JAR
+        // with duplicate entries that some downstream tooling rejects.
+        // The canonical copies live at META-INF/LICENSE and META-INF/NOTICE.
+        exclude("META-INF/LICENSE*", "META-INF/NOTICE*")
         relocate("retrofit2", "dev.cubxity.plugins.metrics.libs.retrofit2")
         relocate("com.charleskorn", "dev.cubxity.plugins.metrics.libs.com.charleskorn")
         relocate("com.influxdb", "dev.cubxity.plugins.metrics.libs.com.influxdb")

--- a/platforms/minestom/build.gradle.kts
+++ b/platforms/minestom/build.gradle.kts
@@ -34,6 +34,12 @@ dependencies {
 tasks {
     shadowJar {
         archiveClassifier.set("")
+        // Shaded deps (okhttp, retrofit, kotlin-stdlib, etc.) each ship
+        // their own META-INF/LICENSE.txt and META-INF/NOTICE.txt. Without
+        // a filter the shadow plugin keeps them all, producing a JAR
+        // with duplicate entries that some downstream tooling rejects.
+        // The canonical copies live at META-INF/LICENSE and META-INF/NOTICE.
+        exclude("META-INF/LICENSE*", "META-INF/NOTICE*")
         relocate("retrofit2", "dev.cubxity.plugins.metrics.libs.retrofit2")
         relocate("com.charleskorn", "dev.cubxity.plugins.metrics.libs.com.charleskorn")
         relocate("com.influxdb", "dev.cubxity.plugins.metrics.libs.com.influxdb")

--- a/platforms/velocity/build.gradle.kts
+++ b/platforms/velocity/build.gradle.kts
@@ -33,6 +33,12 @@ tasks {
     shadowJar {
         archiveClassifier.set("")
         mergeServiceFiles()
+        // Shaded deps (okhttp, retrofit, kotlin-stdlib, etc.) each ship
+        // their own META-INF/LICENSE.txt and META-INF/NOTICE.txt. Without
+        // a filter the shadow plugin keeps them all, producing a JAR
+        // with duplicate entries that some downstream tooling rejects.
+        // The canonical copies live at META-INF/LICENSE and META-INF/NOTICE.
+        exclude("META-INF/LICENSE*", "META-INF/NOTICE*")
         relocate("retrofit2", "dev.cubxity.plugins.metrics.libs.retrofit2")
         relocate("com.charleskorn", "dev.cubxity.plugins.metrics.libs.com.charleskorn")
         relocate("com.influxdb", "dev.cubxity.plugins.metrics.libs.com.influxdb")


### PR DESCRIPTION
## Summary

- Each shaded dependency (okhttp, retrofit, okio, kotlin-stdlib, etc.) ships its own `META-INF/LICENSE.txt` and `META-INF/NOTICE.txt`. The shadow plugin keeps them all by default, so the published JAR carries three copies of each path.
- Paper's plugin remapper rejects the resulting jar on load:

  ```
  java.lang.IllegalStateException: Duplicate entries detected:
    META-INF/LICENSE.txt, META-INF/LICENSE.txt,
    META-INF/NOTICE.txt, META-INF/NOTICE.txt
      at net.neoforged.art.internal.RenamerImpl.run(RenamerImpl.java:191)
  ```

  So `unifiedmetrics-platform-bukkit-0.4.x.jar` cannot be installed on Paper 1.21.x servers (Leaf, MultiPaper, ShreddedPaper).
- Add `exclude("META-INF/LICENSE*", "META-INF/NOTICE*")` to every platform `shadowJar` block. Canonical copies still ship at the root-level `META-INF/LICENSE` / `META-INF/NOTICE` paths, so the LGPL notice obligation is unaffected.

Confirmed both `v0.4.0` and `v0.4.1` artifacts exhibit the duplicate-entry layout (`unzip -l` shows 3 x `LICENSE.txt`, 3 x `NOTICE.txt`).

## Test plan

- [ ] Build the bukkit jar locally and verify `unzip -l build/libs/unifiedmetrics-platform-bukkit-*.jar | grep -E 'LICENSE|NOTICE'` shows only `META-INF/LICENSE` and `META-INF/NOTICE` (no `.txt` duplicates, no other `LICENSE*`/`NOTICE*` entries beyond the unshaded okhttp publicsuffix `NOTICE`).
- [ ] Drop the resulting jar into a Paper 1.21.x server (Leaf, MultiPaper, or ShreddedPaper) plugins folder and confirm `Remapping plugin '...'` succeeds and the plugin enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations across all platforms (Bukkit, Bungee, Minestom, Velocity) to exclude duplicate license and notice metadata files from plugin archives, preventing potential conflicts during installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusk-studio/UnifiedMetrics/pull/10)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->