### PR TITLE
fix(tracing): respect DD_SERVICE and fix span correlation

### DIFF
--- a/platforms/velocity/src/main/kotlin/dev/cubxity/plugins/metrics/velocity/tracing/PlayerTracingListener.kt
+++ b/platforms/velocity/src/main/kotlin/dev/cubxity/plugins/metrics/velocity/tracing/PlayerTracingListener.kt
@@ -187,9 +187,10 @@ internal class PlayerTraceState(
     @Synchronized
     fun startConnection(username: String, attributes: Map<String, String>) {
         if (activeConnectionSpan != null) return
-        if (config.spans.session) {
-            activeConnectionSpan = tracer.startSpan("player.connection", attributes = attributes)
-        }
+        // Always create the connection span so child spans (login, backend_connect,
+        // server_session) share the same trace ID via parent context, even when
+        // session tracking is disabled.
+        activeConnectionSpan = tracer.startSpan("player.connection", attributes = attributes)
     }
 
     @Synchronized

--- a/tracing/otel/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/otel/OtelTracingDriver.kt
+++ b/tracing/otel/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/otel/OtelTracingDriver.kt
@@ -85,7 +85,9 @@ class OtelTracingDriver(
         }
 
         // Build our own SDK + OTLP exporter.
-        val serviceName = config.serviceName.ifBlank { api.serverName }
+        val serviceName = System.getenv("DD_SERVICE")?.takeIf { it.isNotBlank() }
+            ?: System.getenv("OTEL_SERVICE_NAME")?.takeIf { it.isNotBlank() }
+            ?: config.serviceName.ifBlank { api.serverName }
         val deploymentEnv = config.deploymentEnvironment.ifBlank {
             System.getenv("OTEL_DEPLOYMENT_ENVIRONMENT").orEmpty()
         }


### PR DESCRIPTION
## Summary
- OTel driver now checks DD_SERVICE and OTEL_SERVICE_NAME env vars before falling back to config, so the proxy reports under the correct Datadog service name.
- Connection span is always created regardless of spans.session config, ensuring login, backend_connect, and server_session spans share the same trace ID via parent context.

## Test plan
- [ ] CI passes
- [ ] Deploy to hub-ingress, verify traces appear under hub-ingress service in Datadog APM
- [ ] Verify player.login, player.backend_connect, player.server_session share one trace ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed distributed tracing to consistently maintain trace context for child spans, even when certain tracing features are disabled.

* **Improvements**
  * Enhanced service identification to prioritize standard environment-based configuration over application defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusk-studio/UnifiedMetrics/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->