### PR TITLE
feat(velocity): replace long-lived session span with instant connect/disconnect

### DIFF
--- a/common/src/main/kotlin/dev/cubxity/plugins/metrics/common/config/UnifiedMetricsConfig.kt
+++ b/common/src/main/kotlin/dev/cubxity/plugins/metrics/common/config/UnifiedMetricsConfig.kt
@@ -65,18 +65,12 @@ data class UnifiedMetricsTracingConfig(
 
 @Serializable
 data class UnifiedMetricsTracingSpansConfig(
-    /** `player.login` (PreLogin -> PostLogin). */
+    /** `player.login` (PreLogin -> ChooseInitialServer). */
     val login: Boolean = true,
-    /** `player.backend_connect` (ServerPreConnect -> ServerPostConnect). */
-    val backendConnect: Boolean = true,
-    /** `player.server_session` (ServerPostConnect -> next switch / disconnect). */
-    val serverSession: Boolean = true,
-    /**
-     * `player.connection` — the long-lived parent span covering the entire
-     * proxy session. Disabled by default since APM backends typically warn
-     * about hour-long spans.
-     */
-    val session: Boolean = false
+    /** `player.server_connect` (ServerPreConnect -> ServerConnected). */
+    val serverConnect: Boolean = true,
+    /** `player.disconnect` — captures teardown, disconnect reason, and session duration. */
+    val disconnect: Boolean = true
 )
 
 @Serializable

--- a/platforms/velocity/src/main/kotlin/dev/cubxity/plugins/metrics/velocity/tracing/PlayerTracingListener.kt
+++ b/platforms/velocity/src/main/kotlin/dev/cubxity/plugins/metrics/velocity/tracing/PlayerTracingListener.kt
@@ -59,7 +59,6 @@ class PlayerTracingListener(
     fun dispose() {
         bootstrap.server.eventManager.unregisterListener(bootstrap, this)
         bootstrap.server.channelRegistrar.unregister(channel)
-        // End any spans that are still open.
         states.values.forEach { state ->
             safe { state.endAll() }
         }
@@ -86,23 +85,19 @@ class PlayerTracingListener(
                 attrs["player.virtual_host"] = "${it.hostString}:${it.port}"
             }
 
-            // We don't have the UUID until login completes; use username keying for now,
-            // and migrate to UUID in the player-server choice / connect events.
             val state = pendingByName.computeIfAbsent(username) { PlayerTraceState(tracer, tracingConfig) }
-            state.startConnection(username, attrs)
+            state.startConnect(username, attrs)
             state.startLogin()
         }
     }
 
     @Subscribe(order = PostOrder.NORMAL)
     fun onChooseInitialServer(event: PlayerChooseInitialServerEvent) {
-        // PreLoginEvent fires before the Player object exists; at this point we can rebind
-        // the pending state to the player UUID.
         safe {
             val player = event.player
             val pending = pendingByName.remove(player.username)
             val state = pending ?: PlayerTraceState(tracer, tracingConfig).also {
-                it.startConnection(player.username, mapOf("player.username" to player.username))
+                it.startConnect(player.username, mapOf("player.username" to player.username))
             }
             state.bind(player.uniqueId)
             states[player.uniqueId] = state
@@ -116,8 +111,7 @@ class PlayerTracingListener(
         safe {
             val state = states[event.player.uniqueId] ?: return@safe
             val target = event.result.server.orElse(event.originalServer).serverInfo.name
-            state.endServerSession()
-            state.startBackendConnect(target)
+            state.startServerConnect(target)
         }
     }
 
@@ -127,12 +121,9 @@ class PlayerTracingListener(
             val player = event.player
             val state = states[player.uniqueId] ?: return@safe
             val target = event.server.serverInfo.name
-            state.endBackendConnect(target)
-            state.startServerSession(target)
+            state.endServerConnect(target)
 
             if (tracingConfig.propagation) {
-                // Velocity fires ServerConnectedEvent before committing the new
-                // ServerConnection to player.currentServer, so defer until it's populated.
                 bootstrap.server.scheduler
                     .buildTask(bootstrap, Runnable { safe { propagateContext(player, state) } })
                     .delay(100L, TimeUnit.MILLISECONDS)
@@ -163,8 +154,8 @@ class PlayerTracingListener(
 
     private fun propagateContext(player: Player, state: PlayerTraceState) {
         safe {
-            val span = state.activeServerSessionSpan ?: state.activeConnectionSpan ?: return@safe
-            val headers = tracer.inject(span.context)
+            val ctx = state.traceContext ?: return@safe
+            val headers = tracer.inject(ctx)
             val payload = TracingChannels.encode(headers) ?: return@safe
             val server = player.currentServer.orElse(null) ?: return@safe
             server.sendPluginMessage(channel, payload)
@@ -189,28 +180,36 @@ internal class PlayerTraceState(
     private val tracer: Tracer,
     private val config: UnifiedMetricsTracingConfig
 ) {
-    var activeConnectionSpan: Span? = null
+    /** Trace context from the anchor span. All child spans use this as parent. */
+    var traceContext: SpanContext? = null
         private set
+
     private var activeLoginSpan: Span? = null
-    private var activeBackendConnectSpan: Span? = null
-    var activeServerSessionSpan: Span? = null
-        private set
+    private var activeServerConnectSpan: Span? = null
+    private var activeDisconnectSpan: Span? = null
 
     private var uuid: UUID? = null
+    private var username: String? = null
+    private var connectTimeMs: Long = 0
 
+    /**
+     * Create an instant `player.connect` anchor span. This establishes the
+     * trace ID that all subsequent child spans inherit. The span is ended
+     * immediately so no long-lived span sits in memory.
+     */
     @Synchronized
-    fun startConnection(username: String, attributes: Map<String, String>) {
-        if (activeConnectionSpan != null) return
-        // Always create the connection span so child spans (login, backend_connect,
-        // server_session) share the same trace ID via parent context, even when
-        // session tracking is disabled.
-        activeConnectionSpan = tracer.startSpan("player.connection", attributes = attributes)
+    fun startConnect(username: String, attributes: Map<String, String>) {
+        if (traceContext != null) return
+        this.username = username
+        connectTimeMs = System.currentTimeMillis()
+        val anchor = tracer.startSpan("player.connect", attributes = attributes)
+        traceContext = anchor.context
+        anchor.end()
     }
 
     @Synchronized
     fun bind(uuid: UUID) {
         this.uuid = uuid
-        activeConnectionSpan?.setAttribute("player.uuid", uuid.toString())
     }
 
     @Synchronized
@@ -219,7 +218,7 @@ internal class PlayerTraceState(
         if (activeLoginSpan != null) return
         activeLoginSpan = tracer.startSpan(
             "player.login",
-            parent = activeConnectionSpan?.context
+            parent = traceContext
         )
     }
 
@@ -230,76 +229,104 @@ internal class PlayerTraceState(
     }
 
     @Synchronized
-    fun startBackendConnect(target: String) {
-        if (!config.spans.backendConnect) return
-        if (activeBackendConnectSpan != null) {
-            activeBackendConnectSpan?.end()
-        }
-        activeBackendConnectSpan = tracer.startSpan(
-            "player.backend_connect",
-            parent = activeConnectionSpan?.context,
-            attributes = mapOf("target.server" to target)
-        )
-    }
-
-    @Synchronized
-    fun endBackendConnect(target: String) {
-        activeBackendConnectSpan?.setAttribute("target.server", target)
-        activeBackendConnectSpan?.end()
-        activeBackendConnectSpan = null
-    }
-
-    @Synchronized
-    fun startServerSession(target: String) {
-        if (!config.spans.serverSession) return
-        activeServerSessionSpan = tracer.startSpan(
-            "player.server_session",
-            parent = activeConnectionSpan?.context,
+    fun startServerConnect(target: String) {
+        if (!config.spans.serverConnect) return
+        // End any previous server_connect span (defensive; should already be ended).
+        activeServerConnectSpan?.end()
+        activeServerConnectSpan = tracer.startSpan(
+            "player.server_connect",
+            parent = traceContext,
             attributes = mapOf("server.name" to target)
         )
     }
 
     @Synchronized
-    fun endServerSession() {
-        activeServerSessionSpan?.end()
-        activeServerSessionSpan = null
+    fun endServerConnect(target: String) {
+        activeServerConnectSpan?.setAttribute("server.name", target)
+        activeServerConnectSpan?.end()
+        activeServerConnectSpan = null
     }
 
+    /**
+     * Record a kick event. Marks the in-flight server_connect span as error
+     * if the kick happened during connect, and starts the disconnect span
+     * (since a kick initiates the disconnect sequence).
+     */
     @Synchronized
     fun recordKick(server: String, reason: String?, duringConnect: Boolean) {
-        val target = if (duringConnect) activeBackendConnectSpan else activeServerSessionSpan
-        target?.setAttribute("kick.server", server)
-        if (reason != null) target?.setAttribute("kick.reason", reason)
-        target?.setError(reason ?: "kicked")
+        if (duringConnect) {
+            activeServerConnectSpan?.setAttribute("kick.server", server)
+            if (reason != null) activeServerConnectSpan?.setAttribute("kick.reason", reason)
+            activeServerConnectSpan?.setError(reason ?: "kicked")
+        }
+
+        // Start the disconnect span early; the kick is the beginning of disconnect.
+        startDisconnect(
+            reason = reason ?: "kicked",
+            kickServer = server,
+            kickReason = reason
+        )
+        activeDisconnectSpan?.setError(reason ?: "kicked")
     }
 
+    /**
+     * End all open spans. Called from [DisconnectEvent].
+     */
     @Synchronized
     fun endAll(reason: String? = null) {
         val hadOpenLogin = activeLoginSpan != null
-        val hadOpenBackendConnect = activeBackendConnectSpan != null
+        val hadOpenServerConnect = activeServerConnectSpan != null
 
-        activeBackendConnectSpan?.setError(reason ?: "disconnected")
-        activeBackendConnectSpan?.end()
-        activeBackendConnectSpan = null
-
-        activeServerSessionSpan?.apply {
-            if (reason != null) setAttribute("disconnect.reason", reason)
+        if (hadOpenServerConnect) {
+            activeServerConnectSpan?.setError(reason ?: "disconnected")
         }
-        activeServerSessionSpan?.end()
-        activeServerSessionSpan = null
+        activeServerConnectSpan?.end()
+        activeServerConnectSpan = null
 
-        activeLoginSpan?.setError(reason ?: "disconnected")
+        if (hadOpenLogin) {
+            activeLoginSpan?.setError(reason ?: "disconnected")
+        }
         activeLoginSpan?.end()
         activeLoginSpan = null
 
-        activeConnectionSpan?.apply {
-            if (reason != null) setAttribute("disconnect.reason", reason)
-            // Mark connection as error if login or backend connect was still in progress
-            if (hadOpenLogin || hadOpenBackendConnect) {
-                setError(reason ?: "disconnected")
-            }
+        // Create the disconnect span if not already started by a kick.
+        if (activeDisconnectSpan == null) {
+            startDisconnect(reason = reason)
+        } else if (reason != null) {
+            activeDisconnectSpan?.setAttribute("disconnect.reason", reason)
         }
-        activeConnectionSpan?.end()
-        activeConnectionSpan = null
+
+        if (hadOpenLogin || hadOpenServerConnect) {
+            activeDisconnectSpan?.setError(reason ?: "disconnected")
+        }
+
+        activeDisconnectSpan?.end()
+        activeDisconnectSpan = null
+        traceContext = null
+    }
+
+    private fun startDisconnect(
+        reason: String?,
+        kickServer: String? = null,
+        kickReason: String? = null
+    ) {
+        if (!config.spans.disconnect) return
+        if (activeDisconnectSpan != null) return
+
+        val attrs = mutableMapOf<String, String>()
+        username?.let { attrs["player.username"] = it }
+        uuid?.let { attrs["player.uuid"] = it.toString() }
+        if (reason != null) attrs["disconnect.reason"] = reason
+        if (kickServer != null) attrs["kick.server"] = kickServer
+        if (kickReason != null) attrs["kick.reason"] = kickReason
+        if (connectTimeMs > 0) {
+            attrs["session.duration_ms"] = (System.currentTimeMillis() - connectTimeMs).toString()
+        }
+
+        activeDisconnectSpan = tracer.startSpan(
+            "player.disconnect",
+            parent = traceContext,
+            attributes = attrs
+        )
     }
 }

--- a/test-k8s/trace-verifier/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/test/TraceVerifier.kt
+++ b/test-k8s/trace-verifier/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/test/TraceVerifier.kt
@@ -35,11 +35,11 @@ import java.util.concurrent.TimeUnit
 /**
  * End-to-end trace verifier for the UnifiedMetrics OTel tracing driver.
  *
- * Simulates the full proxy→backend tracing flow in two separate
+ * Simulates the full proxy->backend tracing flow in two separate
  * [OtelTracingDriver] instances (mimicking two JVMs) sharing one Jaeger backend:
  *
- *   1. Proxy emits `player.connection` (root) → `player.login`,
- *      `player.backend_connect`, `player.server_session`.
+ *   1. Proxy emits `player.connect` (instant anchor) -> `player.login`,
+ *      `player.server_connect`, `player.disconnect`.
  *   2. Headers are injected via the Tracer and serialized through
  *      [TracingChannels.encode] / [TracingChannels.decode] (the wire format).
  *   3. Backend extracts the context and emits `player.backend.session` as a
@@ -84,31 +84,28 @@ fun main() {
     val proxy = proxyDriver.tracer
     val backend = backendDriver.tracer
 
-    // Simulate proxy lifecycle.
-    val connection = proxy.startSpan(
-        "player.connection",
+    // Simulate proxy lifecycle: instant anchor -> login -> server_connect -> disconnect.
+    val anchor = proxy.startSpan(
+        "player.connect",
         attributes = mapOf("player.username" to "Notch")
     )
-    val login = proxy.startSpan("player.login", parent = connection.context)
+    val traceCtx = anchor.context
+    anchor.end()
+
+    val login = proxy.startSpan("player.login", parent = traceCtx)
     Thread.sleep(20)
     login.end()
 
-    val backendConnect = proxy.startSpan(
-        "player.backend_connect",
-        parent = connection.context,
-        attributes = mapOf("target.server" to "lobby")
-    )
-    Thread.sleep(20)
-    backendConnect.end()
-
-    val serverSession = proxy.startSpan(
-        "player.server_session",
-        parent = connection.context,
+    val serverConnect = proxy.startSpan(
+        "player.server_connect",
+        parent = traceCtx,
         attributes = mapOf("server.name" to "lobby")
     )
+    Thread.sleep(20)
+    serverConnect.end()
 
-    // Wire transfer: proxy → backend via TracingChannels payload.
-    val proxyHeaders = proxy.inject(serverSession.context)
+    // Wire transfer: proxy -> backend via TracingChannels payload.
+    val proxyHeaders = proxy.inject(traceCtx)
     val payload = requireNotNull(TracingChannels.encode(proxyHeaders)) { "encode returned null" }
     val backendHeaders = requireNotNull(TracingChannels.decode(payload)) { "decode returned null" }
     require(proxyHeaders["traceparent"] == backendHeaders["traceparent"]) {
@@ -129,8 +126,17 @@ fun main() {
     )
     Thread.sleep(50)
     backendSpan.end()
-    serverSession.end()
-    connection.end()
+
+    val disconnect = proxy.startSpan(
+        "player.disconnect",
+        parent = traceCtx,
+        attributes = mapOf(
+            "player.username" to "Notch",
+            "disconnect.reason" to "successful_login",
+            "session.duration_ms" to "110"
+        )
+    )
+    disconnect.end()
 
     // The proxy traceparent looks like: 00-<traceId>-<spanId>-<flags>.
     val traceId = backendHeaders["traceparent"]!!.split("-")[1]
@@ -155,10 +161,10 @@ private fun pollJaeger(base: String, traceId: String): Boolean {
     val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60)
     val url = URL("$base/api/traces/$traceId")
     val expected = setOf(
-        "player.connection",
+        "player.connect",
         "player.login",
-        "player.backend_connect",
-        "player.server_session",
+        "player.server_connect",
+        "player.disconnect",
         "player.backend.session"
     )
     val expectedServices = setOf("unifiedmetrics-proxy", "unifiedmetrics-backend")


### PR DESCRIPTION
## Summary

- Replace the long-lived `player.connection` span with an instant `player.connect` anchor that establishes the trace ID and ends immediately
- Add `player.disconnect` span that starts at kick/disconnect and ends at cleanup, with `disconnect.reason`, kick info, and computed `session.duration_ms`
- Rename `player.backend_connect` to `player.server_connect` (no assumption about proxy architecture)
- Remove `player.server_session` (long-lived, replaced by server_connect + disconnect)
- Update trace verifier to match new span model

No long-lived spans remain. The trace in Datadog shows a short burst at connect time (connect, login, server_connect) and a span at disconnect time, all sharing one trace ID.

## Config changes

Backwards-compatible (kaml `strictMode=false` ignores unknown keys):
- `spans.backendConnect` -> `spans.serverConnect`
- `spans.serverSession` removed
- `spans.session` removed
- `spans.disconnect` added (default: true)

## Test plan

- [x] Full Gradle build passes
- [ ] CI passes
- [ ] Deploy to test proxy, connect bot, verify trace structure in Datadog


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New tracing span configuration options now available: `login`, `serverConnect`, and `disconnect`. Previous toggles for `backendConnect`, `serverSession`, and `session` have been removed.

* **Chores**
  * Refactored internal player connection tracing system and updated trace verification to align with updated span sequence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcusk-studio/UnifiedMetrics/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->