### PR TITLE
feat(bukkit): add player.world_ready span

### DIFF
--- a/common/src/main/kotlin/dev/cubxity/plugins/metrics/common/config/UnifiedMetricsConfig.kt
+++ b/common/src/main/kotlin/dev/cubxity/plugins/metrics/common/config/UnifiedMetricsConfig.kt
@@ -70,7 +70,13 @@ data class UnifiedMetricsTracingSpansConfig(
     /** `player.server_connect` (ServerPreConnect -> ServerConnected). */
     val serverConnect: Boolean = true,
     /** `player.disconnect` — captures teardown, disconnect reason, and session duration. */
-    val disconnect: Boolean = true
+    val disconnect: Boolean = true,
+    /**
+     * `player.world_ready` (backend only) — measures time from trace-context
+     * arrival until the player's first movement, approximating how long the
+     * world takes to become playable after connecting to a server.
+     */
+    val worldReady: Boolean = true
 )
 
 @Serializable

--- a/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/tracing/PlayerTracingListener.kt
+++ b/platforms/bukkit/src/main/kotlin/dev/cubxity/plugins/metrics/bukkit/tracing/PlayerTracingListener.kt
@@ -21,11 +21,13 @@ import dev.cubxity.plugins.metrics.api.tracing.Span
 import dev.cubxity.plugins.metrics.api.tracing.Tracer
 import dev.cubxity.plugins.metrics.api.tracing.TracingChannels
 import dev.cubxity.plugins.metrics.bukkit.UnifiedMetricsBukkitPlugin
+import dev.cubxity.plugins.metrics.common.config.UnifiedMetricsTracingConfig
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.HandlerList
 import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerMoveEvent
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.plugin.messaging.PluginMessageListener
 import java.util.UUID
@@ -36,8 +38,10 @@ class PlayerTracingListener(
 ) : Listener, PluginMessageListener {
     private val bootstrap get() = plugin.bootstrap
     private val server get() = bootstrap.server
+    private val tracingConfig: UnifiedMetricsTracingConfig get() = plugin.config.tracing
 
-    private val activeSpans: MutableMap<UUID, Span> = ConcurrentHashMap()
+    private val activeSessionSpans: MutableMap<UUID, Span> = ConcurrentHashMap()
+    private val activeWorldReadySpans: MutableMap<UUID, Span> = ConcurrentHashMap()
 
     private val tracer: Tracer
         get() = plugin.apiProvider.tracingManager.tracer
@@ -54,8 +58,10 @@ class PlayerTracingListener(
         } catch (_: Throwable) {
         }
         HandlerList.unregisterAll(this)
-        activeSpans.values.forEach { safe { it.end() } }
-        activeSpans.clear()
+        activeWorldReadySpans.values.forEach { safe { it.end() } }
+        activeWorldReadySpans.clear()
+        activeSessionSpans.values.forEach { safe { it.end() } }
+        activeSessionSpans.clear()
     }
 
     override fun onPluginMessageReceived(channel: String, player: Player, message: ByteArray) {
@@ -64,26 +70,62 @@ class PlayerTracingListener(
             val headers = TracingChannels.decode(message) ?: return@safe
             val parent = tracer.extract(headers) ?: return@safe
 
-            // End any prior span for this player (e.g. on backend switch via reconnect).
-            activeSpans.remove(player.uniqueId)?.end()
+            // End any prior spans for this player (e.g. on backend switch via reconnect).
+            activeWorldReadySpans.remove(player.uniqueId)?.end()
+            activeSessionSpans.remove(player.uniqueId)?.end()
 
-            val span = tracer.startSpan(
+            val attrs = mapOf(
+                "player.username" to player.name,
+                "player.uuid" to player.uniqueId.toString(),
+                "server.name" to plugin.apiProvider.serverName
+            )
+
+            val session = tracer.startSpan(
                 "player.backend.session",
                 parent = parent,
-                attributes = mapOf(
-                    "player.username" to player.name,
-                    "player.uuid" to player.uniqueId.toString(),
-                    "server.name" to plugin.apiProvider.serverName
-                )
+                attributes = attrs
             )
-            activeSpans[player.uniqueId] = span
+            activeSessionSpans[player.uniqueId] = session
+
+            if (tracingConfig.spans.worldReady) {
+                val worldReady = tracer.startSpan(
+                    "player.world_ready",
+                    parent = parent,
+                    attributes = attrs
+                )
+                activeWorldReadySpans[player.uniqueId] = worldReady
+
+                // Timeout: if the player never moves within 30 seconds, end the
+                // span so it does not leak. This covers AFK joins or unusual
+                // client states.
+                server.scheduler.runTaskLater(bootstrap, Runnable {
+                    safe {
+                        activeWorldReadySpans.remove(player.uniqueId)?.let { span ->
+                            span.setAttribute("world_ready.timeout", true)
+                            span.end()
+                        }
+                    }
+                }, 600L) // 30 seconds = 600 ticks
+            }
         }
+    }
+
+    /**
+     * End the `player.world_ready` span on the player's first movement.
+     * Any [PlayerMoveEvent] (including head rotation) indicates the client
+     * has received enough world data to interact.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onMove(event: PlayerMoveEvent) {
+        val span = activeWorldReadySpans.remove(event.player.uniqueId) ?: return
+        safe { span.end() }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onQuit(event: PlayerQuitEvent) {
         safe {
-            activeSpans.remove(event.player.uniqueId)?.end()
+            activeWorldReadySpans.remove(event.player.uniqueId)?.end()
+            activeSessionSpans.remove(event.player.uniqueId)?.end()
         }
     }
 

--- a/test-k8s/trace-verifier/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/test/TraceVerifier.kt
+++ b/test-k8s/trace-verifier/src/main/kotlin/dev/cubxity/plugins/metrics/tracing/test/TraceVerifier.kt
@@ -124,6 +124,19 @@ fun main() {
             "server.name" to "lobby"
         )
     )
+
+    // Simulate world_ready: span from trace-context arrival to first player move.
+    val worldReady = backend.startSpan(
+        "player.world_ready",
+        parent = parent,
+        attributes = mapOf(
+            "player.username" to "Notch",
+            "server.name" to "lobby"
+        )
+    )
+    Thread.sleep(50)
+    worldReady.end()
+
     Thread.sleep(50)
     backendSpan.end()
 
@@ -163,6 +176,7 @@ private fun pollJaeger(base: String, traceId: String): Boolean {
     val expected = setOf(
         "player.connect",
         "player.login",
+        "player.world_ready",
         "player.server_connect",
         "player.disconnect",
         "player.backend.session"


### PR DESCRIPTION
## Summary
- Adds `player.world_ready` span on the bukkit backend that starts when the proxy's trace context arrives via plugin message and ends on the player's first `PlayerMoveEvent`
- Approximates how long the world takes to become playable after connecting to a server
- 30-second timeout fallback (sets `world_ready.timeout=true` attribute) prevents span leaks for AFK joins
- New `worldReady` toggle in `UnifiedMetricsTracingSpansConfig` (defaults to `true`)
- Updated trace verifier with the new expected span

## Span model after this PR

**Proxy** (velocity): `player.connect` (instant anchor) → `player.login` → `player.server_connect` → `player.disconnect`
**Backend** (bukkit): `player.backend.session` + `player.world_ready`

Both backend spans are parented to the proxy trace via the plugin message channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)